### PR TITLE
RD: replace gouvernement.fr by info.gouv.fr

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -301,7 +301,7 @@
                             <a class="fr-footer__content-link" href="https://legifrance.gouv.fr">legifrance.gouv.fr</a>
                         </li>
                         <li class="fr-footer__content-item">
-                            <a class="fr-footer__content-link" href="https://gouvernement.fr">gouvernement.fr</a>
+                            <a class="fr-footer__content-link" href="https://info.gouv.fr">info.gouv.fr</a>
                         </li>
                         <li class="fr-footer__content-item">
                             <a class="fr-footer__content-link" href="https://service-public.fr">service-public.fr</a>


### PR DESCRIPTION
The address of the official government site has changed and the SIG has asked us to update the footer links.