### PR TITLE
fix: remove the js of the dsfr

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "public/index.html",
   "scripts": {
     "start": "serve",
-    "build": "bash -c 'cp -r node_modules/@gouvfr/dsfr/dist/{dsfr.nomodule.js,dsfr.min.css,fonts,icons,utility} public/assets/'"
+    "build": "bash -c 'cp -r node_modules/@gouvfr/dsfr/dist/{dsfr.min.css,fonts,icons,utility} public/assets/'"
   },
   "repository": {
     "type": "git",

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,6 @@
     <link rel="stylesheet" href="/assets/dsfr.min.css">
     <link rel="stylesheet" href="/assets/utility/utility.css">
     <link rel="stylesheet" href="/application.css">
-    <script type="text/javascript" src="/assets/dsfr.nomodule.js"></script>
 </head>
 <!-- Matomo -->
 <script>


### PR DESCRIPTION
Its fixes this weird case :
![image](https://github.com/user-attachments/assets/023974b7-bb2f-466a-86ad-8a2c495b9c8c)
